### PR TITLE
CKEditor and minor style improvements

### DIFF
--- a/backend/config/plugins.js
+++ b/backend/config/plugins.js
@@ -1,0 +1,195 @@
+// plugins.js
+module.exports = () => {
+  return {
+    // default config from: https://market.strapi.io/plugins/@_sh-strapi-plugin-ckeditor#configuration
+    ckeditor: {
+      enabled: true,
+      config: {
+        plugin: {
+          // disable data-theme tag setting //
+          // setAttribute:false,
+          // disable strapi theme, will use default ckeditor theme //
+          // strapiTheme:false,
+          // styles applied to editor container (global scope) //
+          // styles:`
+          // .ck.ck-editor__main .ck-focused{
+          //   max-height: 700px;
+          // }
+          // :root{
+          //   --ck-color-focus-border:red;
+          //   --ck-color-text:red;
+          // }
+          // `
+        },
+        editor: {
+          // editor default config
+
+          // https://ckeditor.com/docs/ckeditor5/latest/features/markdown.html
+          // if you need markdown support and output set: removePlugins: [''],
+          // default is
+          // removePlugins: ["Markdown"]
+          removePlugins: ["Markdown", "PasteFromOffice", "FontFamily"],
+          forcePasteAsPlainText: true,
+          // https://ckeditor.com/docs/ckeditor5/latest/features/toolbar/toolbar.html
+          toolbar: {
+            items: [
+              "paragraph",
+              "heading1",
+              "heading2",
+              "|",
+              "bold",
+              "italic",
+              "fontColor",
+              "fontBackgroundColor",
+              "underline",
+              "fontSize",
+              "removeFormat",
+              "|",
+              "bulletedList",
+              "todoList",
+              "numberedList",
+              "|",
+              "alignment",
+              "outdent",
+              "indent",
+              "horizontalLine",
+              "|",
+              "StrapiMediaLib",
+              "insertTable",
+              "blockQuote",
+              "mediaEmbed",
+              "link",
+              "highlight",
+              "|",
+              "htmlEmbed",
+              "sourceEditing",
+              "code",
+              "codeBlock",
+              "|",
+              "subscript",
+              "superscript",
+              "strikethrough",
+              "specialCharacters",
+              "|",
+              "heading",
+              "fullScreen",
+              "undo",
+              "redo",
+            ],
+          },
+          // https://ckeditor.com/docs/ckeditor5/latest/features/font.html
+          fontSize: {
+            options: [9, 11, 13, "default", 17, 19, 21, 27, 35],
+            supportAllValues: false,
+          },
+          fontColor: {
+            columns: 5,
+            documentColors: 10,
+          },
+          fontBackgroundColor: {
+            columns: 5,
+            documentColors: 10,
+          },
+          // https://ckeditor.com/docs/ckeditor5/latest/features/ui-language.html
+          language: "pl",
+          // https://ckeditor.com/docs/ckeditor5/latest/features/images/images-overview.html
+          image: {
+            resizeUnit: "%",
+            resizeOptions: [
+              {
+                name: "resizeImage:original",
+                value: null,
+                icon: "original",
+              },
+              {
+                name: "resizeImage:25",
+                value: "25",
+                icon: "small",
+              },
+              {
+                name: "resizeImage:50",
+                value: "50",
+                icon: "medium",
+              },
+              {
+                name: "resizeImage:75",
+                value: "75",
+                icon: "large",
+              },
+            ],
+            toolbar: [
+              "toggleImageCaption",
+              "imageTextAlternative",
+              "imageStyle:inline",
+              "imageStyle:block",
+              "imageStyle:side",
+              "linkImage",
+              "resizeImage:25",
+              "resizeImage:50",
+              "resizeImage:75",
+              "resizeImage:original",
+            ],
+          },
+          // https://ckeditor.com/docs/ckeditor5/latest/features/table.html
+          table: {
+            contentToolbar: [
+              "tableColumn",
+              "tableRow",
+              "mergeTableCells",
+              "tableCellProperties",
+              "tableProperties",
+              "toggleTableCaption",
+            ],
+          },
+          // https://ckeditor.com/docs/ckeditor5/latest/features/headings.html
+          heading: {
+            options: [
+              {
+                model: "paragraph",
+                title: "Paragraph",
+                class: "ck-heading_paragraph",
+              },
+              {
+                model: "heading1",
+                view: "h1",
+                title: "Heading 1",
+                class: "ck-heading_heading1",
+              },
+              {
+                model: "heading2",
+                view: "h2",
+                title: "Heading 2",
+                class: "ck-heading_heading2",
+              },
+              {
+                model: "heading3",
+                view: "h3",
+                title: "Heading 3",
+                class: "ck-heading_heading3",
+              },
+              {
+                model: "heading4",
+                view: "h4",
+                title: "Heading 4",
+                class: "ck-heading_heading4",
+              },
+            ],
+          },
+          // https://ckeditor.com/docs/ckeditor5/latest/features/general-html-support.html
+          // Regular expressions (/.*/  /^(p|h[2-4])$/' etc) for htmlSupport does not allowed in this config
+          htmlSupport: {
+            allow: [
+              {
+                name: "img",
+                attributes: {
+                  sizes: true,
+                  loading: true,
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+  };
+};

--- a/frontend/components/page.tsx
+++ b/frontend/components/page.tsx
@@ -16,6 +16,9 @@ const useStyles = createStyles((theme) => ({
     },
     width: '100%',
   },
+  pageTitle: {
+    width: '100%',
+  },
   breadcrumbs: {
     alignSelf: 'flex-start',
     flexWrap: 'wrap',
@@ -47,7 +50,7 @@ export default function Page({ title, breadcrumbs, align, children }: React.Prop
     <Stack className={classes.page} align={align ?? 'initial'} justify="flex-start" spacing="xl">
       {breadcrumbItems.length > 0 && <Breadcrumbs className={classes.breadcrumbs}>{breadcrumbItems}</Breadcrumbs>}
       {title && (
-        <Stack align="center">
+        <Stack className={classes.pageTitle} align="center">
           <Title order={1} align="center">
             {title}
           </Title>


### PR DESCRIPTION
- Various CKEditor: disabled the 'FontFamily' and 'PasteFromOffice' plugin, pasting data from outside sources shouldn't modify the default fontFamily.
- Title container should now occupy 100% width of the Page component.