### PR TITLE
Upload max file size

### DIFF
--- a/backend/.prettierrc.json
+++ b/backend/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "singleQuote": true,
+  "endOfLine": "auto",
+  "printWidth": 120,
+  "tabWidth": 2,
+  "useTabs": false
+}

--- a/backend/config/middlewares.js
+++ b/backend/config/middlewares.js
@@ -11,11 +11,11 @@ module.exports = [
   {
     name: 'strapi::body',
     config: {
-      formLimit: '5mb', // modify form body
-      jsonLimit: '5mb', // modify JSON body
-      textLimit: '5mb', // modify text body
+      formLimit: '20mb', // modify form body
+      jsonLimit: '20mb', // modify JSON body
+      textLimit: '20mb', // modify text body
       formidable: {
-        maxFileSize: 5 * 1024 * 1024, // multipart data, modify here limit of uploaded file size
+        maxFileSize: 20 * 1024 * 1024, // multipart data, modify here limit of uploaded file size
       },
     },
   },

--- a/backend/config/middlewares.js
+++ b/backend/config/middlewares.js
@@ -5,8 +5,18 @@ module.exports = [
   'strapi::poweredBy',
   'strapi::logger',
   'strapi::query',
-  'strapi::body',
   'strapi::session',
   'strapi::favicon',
   'strapi::public',
+  {
+    name: 'strapi::body',
+    config: {
+      formLimit: '5mb', // modify form body
+      jsonLimit: '5mb', // modify JSON body
+      textLimit: '5mb', // modify text body
+      formidable: {
+        maxFileSize: 5 * 1024 * 1024, // multipart data, modify here limit of uploaded file size
+      },
+    },
+  },
 ];


### PR DESCRIPTION
- Added max transfer size limit to strapi `body` middleware (5MB)
- Created a prettierrc.json for backend.