### PR TITLE
Change Strapi default lang to polish - hack

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -16,9 +16,9 @@
     "develop": "strapi develop",
     "start": "strapi start",
     "build": "strapi build",
-    "build-prod": "yarn run patch-admin && yarn run build",
+    "build-prod": "yarn run patch-strapi && yarn run build",
     "strapi": "strapi",
-    "patch-admin": "node src/extensions/patch-admin.js && patch-package @strapi/admin"
+    "patch-strapi": "node src/extensions/patch-strapi.js && patch-package @strapi/admin"
   },
   "devDependencies": {},
   "strapi": {

--- a/backend/src/admin/app.js
+++ b/backend/src/admin/app.js
@@ -1,5 +1,5 @@
-import logo from './extensions/header-icon.png';
 import favicon from './extensions/favicon.ico';
+import logo from './extensions/header-icon.png';
 
 export default {
   config: {
@@ -9,7 +9,6 @@ export default {
     head: {
       favicon: favicon,
     },
-    locales: ['pl'],
     menu: {
       logo: logo,
     },

--- a/backend/src/extensions/admin/StrapiApp.js
+++ b/backend/src/extensions/admin/StrapiApp.js
@@ -1,0 +1,469 @@
+import { darkTheme, lightTheme } from '@strapi/design-system/themes';
+import invariant from 'invariant';
+import isFunction from 'lodash/isFunction';
+import merge from 'lodash/merge';
+import pick from 'lodash/pick';
+import React from 'react';
+import { Helmet } from 'react-helmet';
+import { BrowserRouter } from 'react-router-dom';
+import AuthLogo from './assets/images/logo_strapi_auth_v4.png';
+import MenuLogo from './assets/images/logo_strapi_menu.png';
+import Providers from './components/Providers';
+import { customFields, Plugin } from './core/apis';
+import configureStore from './core/store/configureStore';
+import { basename, createHook } from './core/utils';
+import {
+  INJECT_COLUMN_IN_TABLE,
+  MUTATE_COLLECTION_TYPES_LINKS,
+  MUTATE_EDIT_VIEW_LAYOUT,
+  MUTATE_SINGLE_TYPES_LINKS,
+} from './exposedHooks';
+import favicon from './favicon.png';
+import injectionZones from './injectionZones';
+import App from './pages/App';
+import languageNativeNames from './translations/languageNativeNames';
+
+class StrapiApp {
+  constructor({ adminConfig, appPlugins, library, middlewares, reducers }) {
+    this.customConfigurations = adminConfig.config;
+    this.customBootstrapConfiguration = adminConfig.bootstrap;
+    this.configurations = {
+      authLogo: AuthLogo,
+      head: { favicon },
+      locales: ['pl'], // #custom-change
+      menuLogo: MenuLogo,
+      notifications: { releases: true },
+      themes: { light: lightTheme, dark: darkTheme },
+      translations: {},
+      tutorials: true,
+    };
+    this.appPlugins = appPlugins || {};
+    this.library = library;
+    this.middlewares = middlewares;
+    this.plugins = {};
+    this.reducers = reducers;
+    this.translations = {};
+    this.hooksDict = {};
+    this.admin = {
+      injectionZones,
+    };
+    this.customFields = customFields;
+
+    this.menu = [];
+    this.settings = {
+      global: {
+        id: 'global',
+        intlLabel: {
+          id: 'Settings.global',
+          defaultMessage: 'Global Settings',
+        },
+        links: [],
+      },
+    };
+  }
+
+  addComponents = (components) => {
+    if (Array.isArray(components)) {
+      components.map((compo) => this.library.components.add(compo));
+    } else {
+      this.library.components.add(components);
+    }
+  };
+
+  addCorePluginMenuLink = (link) => {
+    const stringifiedLink = JSON.stringify(link);
+
+    invariant(link.to, `link.to should be defined for ${stringifiedLink}`);
+    invariant(typeof link.to === 'string', `Expected link.to to be a string instead received ${typeof link.to}`);
+    invariant(
+      ['/plugins/content-type-builder', '/plugins/upload'].includes(link.to),
+      'This method is not available for your plugin'
+    );
+    invariant(
+      link.intlLabel?.id && link.intlLabel?.defaultMessage,
+      `link.intlLabel.id & link.intlLabel.defaultMessage for ${stringifiedLink}`
+    );
+
+    this.menu.push(link);
+  };
+
+  addFields = (fields) => {
+    if (Array.isArray(fields)) {
+      fields.map((field) => this.library.fields.add(field));
+    } else {
+      this.library.fields.add(fields);
+    }
+  };
+
+  addMenuLink = (link) => {
+    const stringifiedLink = JSON.stringify(link);
+
+    invariant(link.to, `link.to should be defined for ${stringifiedLink}`);
+    invariant(typeof link.to === 'string', `Expected link.to to be a string instead received ${typeof link.to}`);
+    invariant(
+      link.intlLabel?.id && link.intlLabel?.defaultMessage,
+      `link.intlLabel.id & link.intlLabel.defaultMessage for ${stringifiedLink}`
+    );
+    invariant(
+      link.Component && typeof link.Component === 'function',
+      `link.Component should be a valid React Component`
+    );
+    invariant(link.icon && typeof link.icon === 'function', `link.Icon should be a valid React Component`);
+
+    this.menu.push(link);
+  };
+
+  addMiddlewares = (middlewares) => {
+    middlewares.forEach((middleware) => {
+      this.middlewares.add(middleware);
+    });
+  };
+
+  addReducers = (reducers) => {
+    Object.keys(reducers).forEach((reducerName) => {
+      this.reducers.add(reducerName, reducers[reducerName]);
+    });
+  };
+
+  addSettingsLink = (sectionId, link) => {
+    invariant(this.settings[sectionId], 'The section does not exist');
+
+    const stringifiedLink = JSON.stringify(link);
+
+    invariant(link.id, `link.id should be defined for ${stringifiedLink}`);
+    invariant(
+      link.intlLabel?.id && link.intlLabel?.defaultMessage,
+      `link.intlLabel.id & link.intlLabel.defaultMessage for ${stringifiedLink}`
+    );
+    invariant(link.to, `link.to should be defined for ${stringifiedLink}`);
+    invariant(
+      link.Component && typeof link.Component === 'function',
+      `link.Component should be a valid React Component`
+    );
+
+    this.settings[sectionId].links.push(link);
+  };
+
+  addSettingsLinks = (sectionId, links) => {
+    invariant(this.settings[sectionId], 'The section does not exist');
+    invariant(Array.isArray(links), 'TypeError expected links to be an array');
+
+    links.forEach((link) => {
+      this.addSettingsLink(sectionId, link);
+    });
+  };
+
+  async bootstrap() {
+    Object.keys(this.appPlugins).forEach((plugin) => {
+      const bootstrap = this.appPlugins[plugin].bootstrap;
+
+      if (bootstrap) {
+        bootstrap({
+          addSettingsLink: this.addSettingsLink,
+          addSettingsLinks: this.addSettingsLinks,
+          getPlugin: this.getPlugin,
+          injectContentManagerComponent: this.injectContentManagerComponent,
+          injectAdminComponent: this.injectAdminComponent,
+          registerHook: this.registerHook,
+        });
+      }
+    });
+
+    if (isFunction(this.customBootstrapConfiguration)) {
+      this.customBootstrapConfiguration({
+        addComponents: this.addComponents,
+        addFields: this.addFields,
+        addMenuLink: this.addMenuLink,
+        addReducers: this.addReducers,
+        addSettingsLink: this.addSettingsLink,
+        addSettingsLinks: this.addSettingsLinks,
+        getPlugin: this.getPlugin,
+        injectContentManagerComponent: this.injectContentManagerComponent,
+        injectAdminComponent: this.injectAdminComponent,
+        registerHook: this.registerHook,
+      });
+    }
+  }
+
+  bootstrapAdmin = async () => {
+    await this.createCustomConfigurations();
+
+    this.createHook(INJECT_COLUMN_IN_TABLE);
+    this.createHook(MUTATE_COLLECTION_TYPES_LINKS);
+    this.createHook(MUTATE_SINGLE_TYPES_LINKS);
+    this.createHook(MUTATE_EDIT_VIEW_LAYOUT);
+
+    return Promise.resolve();
+  };
+
+  createCustomConfigurations = async () => {
+    if (this.customConfigurations?.locales) {
+      this.configurations.locales = ['pl', ...(this.customConfigurations.locales?.filter((loc) => loc !== 'pl') || [])]; // #custom-change
+    }
+
+    if (this.customConfigurations?.auth?.logo) {
+      this.configurations.authLogo = this.customConfigurations.auth.logo;
+    }
+
+    if (this.customConfigurations?.menu?.logo) {
+      this.configurations.menuLogo = this.customConfigurations.menu.logo;
+    }
+
+    if (this.customConfigurations?.head?.favicon) {
+      this.configurations.head.favicon = this.customConfigurations.head.favicon;
+    }
+
+    if (this.customConfigurations?.theme) {
+      const darkTheme = this.customConfigurations.theme.dark;
+      const lightTheme = this.customConfigurations.theme.light;
+
+      if (!darkTheme && !lightTheme) {
+        console.warn(
+          `[deprecated] In future versions, Strapi will stop supporting this theme customization syntax. The theme configuration accepts a light and a dark key to customize each theme separately. See https://docs.strapi.io/developer-docs/latest/development/admin-customization.html#theme-extension.`
+        );
+        merge(this.configurations.themes.light, this.customConfigurations.theme);
+      }
+
+      if (lightTheme) merge(this.configurations.themes.light, lightTheme);
+
+      if (darkTheme) merge(this.configurations.themes.dark, darkTheme);
+    }
+
+    if (this.customConfigurations?.notifications?.releases !== undefined) {
+      this.configurations.notifications.releases = this.customConfigurations.notifications.releases;
+    }
+
+    if (this.customConfigurations?.tutorials !== undefined) {
+      this.configurations.tutorials = this.customConfigurations.tutorials;
+    }
+  };
+
+  createHook = (name) => {
+    this.hooksDict[name] = createHook();
+  };
+
+  createSettingSection = (section, links) => {
+    invariant(section.id, 'section.id should be defined');
+    invariant(section.intlLabel?.id && section.intlLabel?.defaultMessage, 'section.intlLabel should be defined');
+
+    invariant(Array.isArray(links), 'TypeError expected links to be an array');
+    invariant(this.settings[section.id] === undefined, 'A similar section already exists');
+
+    this.settings[section.id] = { ...section, links: [] };
+
+    links.forEach((link) => {
+      this.addSettingsLink(section.id, link);
+    });
+  };
+
+  createStore = () => {
+    const store = configureStore(this.middlewares.middlewares, this.reducers.reducers);
+
+    return store;
+  };
+
+  getAdminInjectedComponents = (moduleName, containerName, blockName) => {
+    try {
+      return this.admin.injectionZones[moduleName][containerName][blockName] || [];
+    } catch (err) {
+      console.error('Cannot get injected component', err);
+
+      return err;
+    }
+  };
+
+  getPlugin = (pluginId) => {
+    return this.plugins[pluginId];
+  };
+
+  async initialize() {
+    Object.keys(this.appPlugins).forEach((plugin) => {
+      this.appPlugins[plugin].register(this);
+    });
+  }
+
+  injectContentManagerComponent = (containerName, blockName, component) => {
+    invariant(
+      this.admin.injectionZones.contentManager[containerName]?.[blockName],
+      `The ${containerName} ${blockName} zone is not defined in the content manager`
+    );
+    invariant(component, 'A Component must be provided');
+
+    this.admin.injectionZones.contentManager[containerName][blockName].push(component);
+  };
+
+  injectAdminComponent = (containerName, blockName, component) => {
+    invariant(
+      this.admin.injectionZones.admin[containerName]?.[blockName],
+      `The ${containerName} ${blockName} zone is not defined in the admin`
+    );
+    invariant(component, 'A Component must be provided');
+
+    this.admin.injectionZones.admin[containerName][blockName].push(component);
+  };
+
+  /**
+   * Load the admin translations
+   * @returns {Object} The imported admin translations
+   */
+  async loadAdminTrads() {
+    const arrayOfPromises = this.configurations.locales.map((locale) => {
+      return import(/* webpackChunkName: "[request]" */ `./translations/${locale}.json`)
+        .then(({ default: data }) => {
+          return { data, locale };
+        })
+        .catch(() => {
+          return { data: null, locale };
+        });
+    });
+    const adminLocales = await Promise.all(arrayOfPromises);
+
+    const translations = adminLocales.reduce((acc, current) => {
+      if (current.data) {
+        acc[current.locale] = current.data;
+      }
+
+      return acc;
+    }, {});
+
+    return translations;
+  }
+
+  /**
+   * Load the application's translations and merged the custom translations
+   * with the default ones.
+   *
+   */
+  async loadTrads() {
+    const adminTranslations = await this.loadAdminTrads();
+
+    const arrayOfPromises = Object.keys(this.appPlugins)
+      .map((plugin) => {
+        const registerTrads = this.appPlugins[plugin].registerTrads;
+
+        if (registerTrads) {
+          return registerTrads({ locales: this.configurations.locales });
+        }
+
+        return null;
+      })
+      .filter((a) => a);
+
+    const pluginsTrads = await Promise.all(arrayOfPromises);
+    const mergedTrads = pluginsTrads.reduce((acc, currentPluginTrads) => {
+      const pluginTrads = currentPluginTrads.reduce((acc1, current) => {
+        acc1[current.locale] = current.data;
+
+        return acc1;
+      }, {});
+
+      Object.keys(pluginTrads).forEach((locale) => {
+        acc[locale] = { ...acc[locale], ...pluginTrads[locale] };
+      });
+
+      return acc;
+    }, {});
+
+    const translations = this.configurations.locales.reduce((acc, current) => {
+      acc[current] = {
+        ...adminTranslations[current],
+        ...(mergedTrads[current] || {}),
+        ...this.customConfigurations?.translations?.[current],
+      };
+
+      return acc;
+    }, {});
+
+    this.configurations.translations = translations;
+
+    return Promise.resolve();
+  }
+
+  registerHook = (name, fn) => {
+    invariant(
+      this.hooksDict[name],
+      `The hook ${name} is not defined. You are trying to register a hook that does not exist in the application.`
+    );
+    this.hooksDict[name].register(fn);
+  };
+
+  registerPlugin = (pluginConf) => {
+    const plugin = Plugin(pluginConf);
+
+    this.plugins[plugin.pluginId] = plugin;
+  };
+
+  runHookSeries = (name, asynchronous = false) =>
+    asynchronous ? this.hooksDict[name].runSeriesAsync() : this.hooksDict[name].runSeries();
+
+  runHookWaterfall = (name, initialValue, asynchronous = false, store) => {
+    return asynchronous
+      ? this.hooksDict[name].runWaterfallAsync(initialValue, store)
+      : this.hooksDict[name].runWaterfall(initialValue, store);
+  };
+
+  runHookParallel = (name) => this.hooksDict[name].runParallel();
+
+  render() {
+    const store = this.createStore();
+    const localeNames = pick(languageNativeNames, this.configurations.locales || []);
+
+    const {
+      components: { components },
+      fields: { fields },
+    } = this.library;
+
+    // #custom-change (htmlAttributes and meta)
+
+    return (
+      <Providers
+        authLogo={this.configurations.authLogo}
+        components={components}
+        fields={fields}
+        customFields={this.customFields}
+        localeNames={localeNames}
+        getAdminInjectedComponents={this.getAdminInjectedComponents}
+        getPlugin={this.getPlugin}
+        messages={this.configurations.translations}
+        menu={this.menu}
+        menuLogo={this.configurations.menuLogo}
+        plugins={this.plugins}
+        runHookParallel={this.runHookParallel}
+        runHookWaterfall={(name, initialValue, async = false) => {
+          return this.runHookWaterfall(name, initialValue, async, store);
+        }}
+        runHookSeries={this.runHookSeries}
+        themes={this.configurations.themes}
+        settings={this.settings}
+        showTutorials={this.configurations.tutorials}
+        showReleaseNotification={this.configurations.notifications.releases}
+        store={store}
+      >
+        <>
+          <Helmet
+            link={[
+              {
+                rel: 'icon',
+                type: 'image/png',
+                href: this.configurations.head.favicon,
+              },
+            ]}
+            htmlAttributes={{ lang: 'pl', class: 'notranslate', translate: 'no' }}
+            meta={[
+              {
+                name: 'google',
+                content: 'notranslate',
+              },
+            ]}
+          />
+          <BrowserRouter basename={basename}>
+            <App store={store} />
+          </BrowserRouter>
+        </>
+      </Providers>
+    );
+  }
+}
+
+export default ({ adminConfig = {}, appPlugins, library, middlewares, reducers }) =>
+  new StrapiApp({ adminConfig, appPlugins, library, middlewares, reducers });

--- a/backend/src/extensions/admin/components/LanguageProvider/index.js
+++ b/backend/src/extensions/admin/components/LanguageProvider/index.js
@@ -1,0 +1,53 @@
+/*
+ *
+ * LanguageProvider
+ *
+ * this component connects the redux state language locale to the
+ * IntlProvider component and i18n messages (loaded from `app/translations`)
+ */
+
+import defaultsDeep from 'lodash/defaultsDeep';
+import PropTypes from 'prop-types';
+import React, { useEffect, useReducer } from 'react';
+import { IntlProvider } from 'react-intl';
+import LocalesProvider from '../LocalesProvider';
+import init from './init';
+import reducer, { initialState } from './reducer';
+import localStorageKey from './utils/localStorageKey';
+
+const LanguageProvider = ({ children, localeNames, messages }) => {
+  const [{ locale }, dispatch] = useReducer(reducer, initialState, () => init(localeNames));
+
+  useEffect(() => {
+    // Set user language in local storage.
+    window.localStorage.setItem(localStorageKey, locale);
+    document.documentElement.setAttribute('lang', locale);
+  }, [locale]);
+
+  const changeLocale = (locale) => {
+    dispatch({
+      type: 'CHANGE_LOCALE',
+      locale,
+    });
+  };
+
+  const appMessages = defaultsDeep(messages[locale], messages.en);
+
+  // #custom-change (defaultLocale)
+
+  return (
+    <IntlProvider locale={locale} defaultLocale="pl" messages={appMessages} textComponent="span">
+      <LocalesProvider changeLocale={changeLocale} localeNames={localeNames} messages={appMessages}>
+        {children}
+      </LocalesProvider>
+    </IntlProvider>
+  );
+};
+
+LanguageProvider.propTypes = {
+  children: PropTypes.element.isRequired,
+  localeNames: PropTypes.objectOf(PropTypes.string).isRequired,
+  messages: PropTypes.object.isRequired,
+};
+
+export default LanguageProvider;

--- a/backend/src/extensions/admin/components/LanguageProvider/init.js
+++ b/backend/src/extensions/admin/components/LanguageProvider/init.js
@@ -1,0 +1,13 @@
+import localStorageKey from './utils/localStorageKey';
+
+const init = (localeNames) => {
+  const languageFromLocaleStorage = window.localStorage.getItem(localStorageKey);
+  const appLanguage = localeNames[languageFromLocaleStorage] ? languageFromLocaleStorage : 'pl'; // #custom-change
+
+  return {
+    locale: appLanguage,
+    localeNames,
+  };
+};
+
+export default init;

--- a/backend/src/extensions/admin/components/LanguageProvider/reducer.js
+++ b/backend/src/extensions/admin/components/LanguageProvider/reducer.js
@@ -1,0 +1,30 @@
+/*
+ *
+ * LanguageProvider reducer
+ *
+ */
+
+const initialState = {
+  localeNames: { pl: 'Polski' }, // #custom-change
+  locale: 'pl', // #custom-change
+};
+
+const languageProviderReducer = (state = initialState, action) => {
+  switch (action.type) {
+    case 'CHANGE_LOCALE': {
+      const { locale } = action;
+
+      if (!state.localeNames[locale]) {
+        return state;
+      }
+
+      return { ...state, locale };
+    }
+    default: {
+      return state;
+    }
+  }
+};
+
+export default languageProviderReducer;
+export { initialState };

--- a/backend/src/extensions/admin/pages/homepage/index.js
+++ b/backend/src/extensions/admin/pages/homepage/index.js
@@ -3,9 +3,9 @@
  *
  */
 
-import React, { memo } from 'react';
-import { LoadingIndicatorPage } from '@strapi/helper-plugin';
 import { Layout } from '@strapi/design-system/Layout';
+import { LoadingIndicatorPage } from '@strapi/helper-plugin';
+import React, { memo } from 'react';
 import { useModels } from '../../hooks';
 
 const HomePage = () => {
@@ -15,10 +15,9 @@ const HomePage = () => {
     return <LoadingIndicatorPage />;
   }
 
-  return (
-    <Layout>
-    </Layout>
-  );
+  // #custom-change (removed everything besides main layout)
+
+  return <Layout></Layout>;
 };
 
 export default memo(HomePage);

--- a/backend/src/extensions/patch-strapi.js
+++ b/backend/src/extensions/patch-strapi.js
@@ -1,5 +1,5 @@
 /*
-  Script for copying the files with custom changes to admin and dashboard panels,
+  Script for copying the files with custom changes to admin, dashboard panels and plugins,
   which is then used by the 'patch-package' to apply it directly in the source code of strapi package.
   For now there is no recommended solution to apply such changes in the strapi v4.
   source: https://forum.strapi.io/t/customize-the-dashboard-welcome-page/939/24


### PR DESCRIPTION
Replacing Strapi library internal files with custom ones to force the polish locale to be a default one (changes to Strapiapp.js and LanguageProvider component files). Custom changes are marked by '#custom-change' comment (for easier comparison during updates and general maintenance).